### PR TITLE
Manifest fix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "start": "npm run serve",
     "serve": "node dist/src",
     "start:dev": "ts-node src | pino-pretty",
-    "upgrade-interactive": "npm-check --update",
-    "rimraf": "./node_modules/rimraf/bin.js"
+    "upgrade-interactive": "npm-check --update"
   },
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Remove rimraf script from the package.json

The cause of the deployment problem was in the build stage of the pipeline not doing npm ci inside the root of the project, causing an module not found error during the deploy stage.