### PR TITLE
add margin to space out nav-bar options on mobile screen

### DIFF
--- a/web-app/src/components/Navbar.js
+++ b/web-app/src/components/Navbar.js
@@ -101,6 +101,10 @@ const StyledLi = styled.li`
   padding: 1rem;
   width: 100%;
 
+  @media (max-width: ${devices.mobile}) {
+    margin: 10px 0;
+  }
+
   @media (max-width: ${devices.ipad}) {
     padding: 0 0.5rem;
   }

--- a/web-app/src/components/Navbar.js
+++ b/web-app/src/components/Navbar.js
@@ -124,6 +124,10 @@ const StyledLink = styled(NavLink)`
   @media (max-width: ${devices.ipad}) {
     font-size: 9px;
     line-height: 11px;
+    &.active {
+      font-weight: bold;
+      border-bottom: none;
+    }
   }
 `;
 

--- a/web-app/src/components/__snapshots__/Navbar.spec.js.snap
+++ b/web-app/src/components/__snapshots__/Navbar.spec.js.snap
@@ -107,6 +107,12 @@ exports[`the Navbar component should match the snapshot when open is false 1`] =
   }
 }
 
+@media (max-width:576px) {
+  .c4 {
+    margin: 10px 0;
+  }
+}
+
 @media (max-width:768px) {
   .c4 {
     padding: 0 0.5rem;
@@ -270,6 +276,12 @@ exports[`the Navbar component should match the snapshot when open is true 1`] = 
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+  }
+}
+
+@media (max-width:576px) {
+  .c4 {
+    margin: 10px 0;
   }
 }
 


### PR DESCRIPTION
Solved this issue: https://trello.com/c/PXEgjQ2f/79-navigation-menu-on-mobile-issue
See if you agree or if a better spacing is required