### PR TITLE
Fixing facebook deep links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10435,6 +10435,11 @@
         }
       }
     },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "multer": "^1.4.2",
     "opentracing": "^0.14.4",
     "pino": "^6.0.0",
+    "platform": "^1.3.6",
     "reflect-metadata": "^0.1.13",
     "routing-controllers": "^0.9.0-alpha.6",
     "rxjs": "^6.5.2",

--- a/web-app/src/components/Footer.js
+++ b/web-app/src/components/Footer.js
@@ -6,6 +6,7 @@ import devices from "../styles/Devices";
 import Instagram from "../assets/images/Instagram.svg";
 import Facebook from "../assets/images/Facebook.svg";
 import Twitter from "../assets/images/Twitter.svg";
+var platform = require('platform');
 
 const Footer = () => {
   return (
@@ -24,13 +25,7 @@ const Footer = () => {
           >
             <StyledImage src={Instagram} alt="Instagram" />
           </StyledAnchor>
-          <StyledAnchor
-            href="https://www.facebook.com/Lebanonreliefnetwork"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <StyledImage src={Facebook} alt="Facebook" />
-          </StyledAnchor>
+          <FBAnchor />
           <StyledAnchor
             href="https://twitter.com/LebReliefNet"
             target="_blank"
@@ -44,6 +39,60 @@ const Footer = () => {
     </StyledSection>
   );
 };
+
+const FBAnchor = () => {
+  const os = platform.os.toString();
+  const isAndroid = os.match(/android/i);
+  const isIOS = os.match(/iOS/i);
+  if (isIOS){
+    return(
+      <StyledAnchor
+        href="fb://page/?id=100368885336321";
+        onClick={handleFbClick}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <StyledImage src={Facebook} alt="Facebook" />
+      </StyledAnchor>
+    );
+  } else if (isAndroid){
+      return(
+        <StyledAnchor
+          href="intent://page/100368885336321?referrer=app_link#Intent;package=com.facebook.katana;scheme=fb;end";
+          onClick={handleFbClick}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <StyledImage src={Facebook} alt="Facebook" />
+        </StyledAnchor>
+      );
+  } else {
+      return(
+        <StyledAnchor
+          href="https://www.facebook.com/Lebanonreliefnetwork";
+          onClick={handleFbClick}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <StyledImage src={Facebook} alt="Facebook" />
+        </StyledAnchor>
+      );
+  }
+}
+
+const handleFbClick = (e) => {
+  e.preventDefault();
+  const os = platform.os.toString();
+  const isAndroid = os.match(/android/i);
+  const isIOS = os.match(/iOS/i);
+  if (isIOS){
+    window.location = "fb://page/?id=100368885336321";
+  } else if (isAndroid){
+      window.location = "intent://page/100368885336321?referrer=app_link#Intent;package=com.facebook.katana;scheme=fb;end";
+  } else {
+      window.location = "https://www.facebook.com/Lebanonreliefnetwork";
+  }
+}
 
 const StyledAnchor = styled.a`
   margin: 5%;


### PR DESCRIPTION
"On the bottom banner, clicking on the Instagram and Twitter logo, opens the corresponding when on mobile (Android / Chrome & iOS / Safari).
Clicking on the Facebook opens the m.facebook.xx page on the browser, rather than the app."
Used package.js and 'deep' link urls